### PR TITLE
Extractor sdk - fix sentence transofrmers embedding import error

### DIFF
--- a/embedding/minilm-l6/minilm_l6.py
+++ b/embedding/minilm-l6/minilm_l6.py
@@ -6,7 +6,7 @@ from indexify_extractor_sdk.embedding.sentence_transformer import SentenceTransf
 class MiniLML6Extractor(BaseEmbeddingExtractor):
     name = "tensorlake/minilm-l6"
     description = "MiniLM-L6 Sentence Transformer"
-    python_dependencies = ["torch", "transformers"]
+    python_dependencies = ["torch", "transformers", "langchain"]
     system_dependencies = []
 
     def __init__(self):

--- a/extractor-sdk/indexify_extractor_sdk/__init__.py
+++ b/extractor-sdk/indexify_extractor_sdk/__init__.py
@@ -1,5 +1,4 @@
 from .base_extractor import Content, Extractor, Feature, EmbeddingSchema
-from .embedding.sentence_transformer import SentenceTransformersEmbedding
 
 
 __all__ = [
@@ -7,5 +6,4 @@ __all__ = [
     "EmbeddingSchema",
     "Extractor",
     "Feature",
-    "SentenceTransformersEmbedding",
 ]

--- a/extractor-sdk/pyproject.toml
+++ b/extractor-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexify-extractor-sdk"
-version = "0.0.36"
+version = "0.0.37"
 description = "Indexify Extractor SDK to build new extractors for extraction from unstructured data"
 authors = ["Diptanu Gon Choudhury <diptanu@tensorlake.ai>"]
 readme = "README.md"


### PR DESCRIPTION
SentenceTransformersEmbedding needs to now be imported directly after removing langchain, torch, transformers from sdk deps
Update minilm deps