### PR TITLE
reduce default number of workers

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/main.py
+++ b/extractor-sdk/indexify_extractor_sdk/main.py
@@ -76,7 +76,7 @@ def join(
     ingestion_addr: str = "localhost:8900",
     workers: Annotated[
         int, typer.Option(help="number of worker processes for extraction")
-    ] = cpu_count,
+    ] = 2,
 ):
     print_version()
     if not extractor:


### PR DESCRIPTION
Using cpu count for the number of workers doesn't always work, resulting in a hang. Reduce default to 2.