### PR TITLE
Fix wikipedia extractor + add sample_html

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/base_extractor.py
+++ b/extractor-sdk/indexify_extractor_sdk/base_extractor.py
@@ -201,6 +201,15 @@ class Extractor(ABC):
         )
         f = open(file_name, "rb")
         return Content(content_type="application/pdf", data=f.read(), features=features)
+    
+    def sample_html(self, features: List[Feature] = []) -> Content:
+        file_name = "sample.html"
+        self._download_file(
+            "https://extractor-files.diptanu-6d5.workers.dev/sample.html",
+            file_name,
+        )
+        f = open(file_name, "rb")
+        return Content(content_type="text/html", data=f.read(), features=features)
 
 
 class ExtractorWrapper:

--- a/extractor-sdk/pyproject.toml
+++ b/extractor-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexify-extractor-sdk"
-version = "0.0.40"
+version = "0.0.41"
 description = "Indexify Extractor SDK to build new extractors for extraction from unstructured data"
 authors = ["Diptanu Gon Choudhury <diptanu@tensorlake.ai>"]
 readme = "README.md"

--- a/html/wikipedia/wikipedia.py
+++ b/html/wikipedia/wikipedia.py
@@ -1,4 +1,4 @@
-from utils.utils import extract_images, extract_infobox, extract_sections, extract_title
+from .utils.utils import extract_images, extract_infobox, extract_sections, extract_title
 
 from typing import List, Union
 from indexify_extractor_sdk.base_extractor import Content, Extractor, Feature
@@ -43,13 +43,7 @@ class WikipediaExtractor(Extractor):
         return output
 
     def sample_input(self) -> Content:
-        with open("sample.html", "r") as f:
-            data = f.read()
-
-        return Content(
-            data=data,
-            content_type="text/html",
-        )
+        return self.sample_html()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Wikipedia utils import needed to be prefixed with "."
Add sample_html method in extractor sdk