### PR TITLE
Column comment support to extractor

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/base_extractor.py
+++ b/extractor-sdk/indexify_extractor_sdk/base_extractor.py
@@ -36,6 +36,7 @@ class Feature(BaseModel):
     feature_type: Literal["embedding", "metadata"]
     name: str
     value: Json
+    comment: Optional[Json]
 
     @classmethod
     def embedding(cls, values: List[float], name: str = "embedding", distance="cosine"):
@@ -47,8 +48,10 @@ class Feature(BaseModel):
         )
 
     @classmethod
-    def metadata(cls, value: Json, name: str = "metadata"):
-        return cls(feature_type="metadata", name=name, value=json.dumps(value))
+    def metadata(cls, value: Json, comment: Json = None, name: str = "metadata"):
+        value = json.dumps(value)
+        comment = json.dumps(comment) if comment is not None else None
+        return cls(feature_type="metadata", name=name, value=value, comment=comment)
 
     def get_schema(self) -> dict:
         if self.feature_type == "embedding":
@@ -64,6 +67,10 @@ class Feature(BaseModel):
             print(metadata_schema)
             for k, v in metadata_schema["properties"].items():
                 schema[k] = {"type": v["type"]}
+
+                if self.comment is not None and k in self.comment:
+                    schema[k]["comment"] = self.comment[k]
+            
             return schema
 
 

--- a/image/yolo/yolo_extractor.py
+++ b/image/yolo/yolo_extractor.py
@@ -29,7 +29,10 @@ class YoloExtractor(Extractor):
                 b = box.xyxy[0]
                 c = box.cls
                 name = self.model.names[int(c)]
-                feature = Feature.metadata({"bounding_box": b.tolist(), "object_name": name})
+                feature = Feature.metadata(
+                    value={"bounding_box": b.tolist(), "object_name": name},
+                    comment={"bounding_box": "Bounding box coordinates in the format [x1, y1, x2, y2]"}
+                )
                 features.append(feature)
 
         return features


### PR DESCRIPTION
I've updated the Feature.metadata to include an additional comment field.
This will be used as column comments when constructing SQL DDLs on the server.
I've also modified the yolo extractor to add a comment to the bounding_box field.
Previously, this was only defined as a LIST type, which limited the LLM's ability to verify the format of values in bounding_box when querying schema information. Now, the comment will provide this detail.