### PR TITLE
remove --no-deps flag from downloader

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/downloader.py
+++ b/extractor-sdk/indexify_extractor_sdk/downloader.py
@@ -65,7 +65,7 @@ def install_dependencies(directory_path):
         subprocess.check_call(['virtualenv', '-p', f"python{version_str}", venv_path])
         pip_path = os.path.join(venv_path, 'bin', 'pip')
 
-        subprocess.check_call([pip_path, 'install', '--no-deps', '-r', requirements_path])
+        subprocess.check_call([pip_path, 'install', '-r', requirements_path])
         subprocess.check_call([pip_path, 'install', 'indexify-extractor-sdk'])
 
     # print instructions for next steps


### PR DESCRIPTION
Found an issue that cause the error to happens when trying to run `indexify-extractor download` without a virtual environment.

### Steps to reproduce

```bash
indexify-extractor download hub://image/yolo
source /Users/Home/.indexify-extractors/yolo/ve/bin/activate
indexify-extractor join-server yolo.yolo_extractor:YoloExtractor
```

### Cause

Due to the different environment where the extractor is downloaded and the extractor is ran, the dependencies required by the extractor might not be properly installed.

### Solution

This PR removes the `--no-deps` flag when downloading without a virtual environment giving the extractor's virtual environment (~/.indexify-extractors/yolo/ve) the dependencies it needed to run on the generated virtual environment.