### PR TITLE
add store extractor to local db on download

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/downloader.py
+++ b/extractor-sdk/indexify_extractor_sdk/downloader.py
@@ -188,17 +188,17 @@ def download_extractor(extractor_path):
         os.path.expanduser("~"), ".indexify-extractors", base_extractor_path
     )
 
+    fs.get(extractor_path, directory_path, recursive=True)
+    install_dependencies(directory_path)
+
     # Store the extractor info in the database
 
     extractor_full_name = get_extractor_full_name(base_extractor_path)
+    description = get_extractor_description(extractor_full_name)
 
     try:
-        description = get_extractor_description(extractor_full_name)
         save_extractor_description(extractor_full_name, description)
     except Exception as e:
         print(f"Error saving extractor description: {e}")
         raise e
-
-    fs.get(extractor_path, directory_path, recursive=True)
-    install_dependencies(directory_path)
 

--- a/extractor-sdk/indexify_extractor_sdk/downloader.py
+++ b/extractor-sdk/indexify_extractor_sdk/downloader.py
@@ -98,6 +98,7 @@ def create_extractor_db():
 
     # If the table exists, return
     if  cur.fetchone():
+        conn.close()
         return
 
     # Create the table

--- a/extractor-sdk/indexify_extractor_sdk/downloader.py
+++ b/extractor-sdk/indexify_extractor_sdk/downloader.py
@@ -1,3 +1,5 @@
+import sqlite3
+import json
 import fsspec
 import os
 import sys
@@ -5,6 +7,8 @@ import ast
 import subprocess
 from rich.console import Console
 from rich.panel import Panel
+from .extractor_worker import ExtractorWrapper
+from .base_extractor import ExtractorDescription
 
 console = Console()
 
@@ -70,15 +74,102 @@ def install_dependencies(directory_path):
 
     # print instructions for next steps
     print_instructions(directory_path)
-        
+
+def create_extractor_db():
+    # Connect to the database
+    conn = sqlite3.connect("/tmp/indexify-extractors.db")
+    cur = conn.cursor()
+
+    # Check if the table exists
+    table_name = "extractors"
+    cur.execute(f"""
+        SELECT name 
+        FROM sqlite_master 
+        WHERE type='table' 
+        AND name='{table_name}'
+    """)
+
+    if not cur.fetchone():
+        # Create the table
+        # ID is the full extractor name: minilm-l6.minilm_l6:MiniLML6Extractor
+        cur.execute(f"""
+            CREATE TABLE {table_name} (
+                id TEXT NOT NULL PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT,
+                input_params TEXT,
+                input_mime_types TEXT,
+                metadata_schemas TEXT,
+                embedding_schemas TEXT
+            )
+        """)
+
+    conn.commit()
+    conn.close()
+
+def get_extractor_description(name: str) -> ExtractorDescription:
+    module, cls = name.split(":")
+    wrapper = ExtractorWrapper(module, cls)
+    return wrapper.describe()
+
+def get_extractor_full_name(directory: str):
+    path = os.path.join(os.path.expanduser("~"), ".indexify-extractors", directory)
+    name = find_extractor_subclasses(path)
+    return f"{directory}.{name}"
+
+def serialize_embedding_schemas(embedding_schemas) -> str:
+    schemas = {}
+    for name, embedding_schema in embedding_schemas.items():
+        schemas[name] = embedding_schema.model_dump_json()
+    return json.dumps(schemas)
+
+def save_extractor_description(id: str, description: ExtractorDescription):
+    conn = sqlite3.connect("/tmp/indexify-extractors.db")
+    cur = conn.cursor()
+
+    input_params: str = description.input_params if description.input_params else None
+
+    # Convert the lists to JSON strings
+    mime_types = json.dumps(description.input_mime_types)
+    embedding_schemas = serialize_embedding_schemas(description.embedding_schemas)
+    metadata_schemas = json.dumps(description.metadata_schemas)
+
+    cur.execute(f"""
+        INSERT INTO extractors (
+            id, name, description, input_params, input_mime_types, metadata_schemas, embedding_schemas
+        ) VALUES (
+            '{id}', '{description.name}', '{description.description}',
+            '{input_params}', '{mime_types}',
+            '{metadata_schemas}', '{embedding_schemas}'
+        )
+    """)
+
+    conn.commit()
+    conn.close()
 
 def download_extractor(extractor_path):
+    # Create extractor database if not exists
+    create_extractor_db()
+
     console.print("[bold #4AA4F4]Downloading Extractor...[/]")
     extractor_path = extractor_path.removeprefix("hub://")
     fs = fsspec.filesystem("github", org="tensorlakeai", repo="indexify-extractors")
+
+    base_extractor_path = os.path.basename(extractor_path)
     directory_path = os.path.join(
-        os.path.expanduser("~"), ".indexify-extractors", os.path.basename(extractor_path)
+        os.path.expanduser("~"), ".indexify-extractors", base_extractor_path
     )
+
+    # Store the extractor info in the database
+
+    extractor_full_name = get_extractor_full_name(base_extractor_path)
+
+    try:
+        description = get_extractor_description(extractor_full_name)
+        save_extractor_description(extractor_full_name, description)
+    except Exception as e:
+        print(f"Error saving extractor description: {e}")
+
     fs.get(extractor_path, directory_path, recursive=True)
     install_dependencies(directory_path)
 

--- a/extractor-sdk/indexify_extractor_sdk/downloader.py
+++ b/extractor-sdk/indexify_extractor_sdk/downloader.py
@@ -75,9 +75,16 @@ def install_dependencies(directory_path):
     # print instructions for next steps
     print_instructions(directory_path)
 
+def get_db_path():
+    """Returns the path the extractors database file."""
+    base_path = os.path.join(os.path.expanduser("~"), ".indexify-extractors")
+    db_path = os.path.join(base_path, "extractors.db")
+    return db_path
+
 def create_extractor_db():
     # Connect to the database
-    conn = sqlite3.connect("/tmp/indexify-extractors.db")
+    path = get_db_path()
+    conn = sqlite3.connect(path)
     cur = conn.cursor()
 
     # Check if the table exists
@@ -127,7 +134,8 @@ def serialize_embedding_schemas(embedding_schemas) -> str:
     return json.dumps(schemas)
 
 def save_extractor_description(id: str, description: ExtractorDescription):
-    conn = sqlite3.connect("/tmp/indexify-extractors.db")
+    db_path = get_db_path()
+    conn = sqlite3.connect(db_path)
     cur = conn.cursor()
 
     # Check if the extractor already exists

--- a/extractor-sdk/indexify_extractor_sdk/downloader.py
+++ b/extractor-sdk/indexify_extractor_sdk/downloader.py
@@ -197,6 +197,7 @@ def download_extractor(extractor_path):
         save_extractor_description(extractor_full_name, description)
     except Exception as e:
         print(f"Error saving extractor description: {e}")
+        raise e
 
     fs.get(extractor_path, directory_path, recursive=True)
     install_dependencies(directory_path)

--- a/extractor-sdk/indexify_extractor_sdk/downloader.py
+++ b/extractor-sdk/indexify_extractor_sdk/downloader.py
@@ -190,7 +190,6 @@ def download_extractor(extractor_path):
     )
 
     fs.get(extractor_path, directory_path, recursive=True)
-    install_dependencies(directory_path)
 
     # Store the extractor info in the database
 
@@ -203,3 +202,4 @@ def download_extractor(extractor_path):
         print(f"Error saving extractor description: {e}")
         raise e
 
+    install_dependencies(directory_path)


### PR DESCRIPTION
This PR adds several functionality required to save the extractor description to SQLite database locally:

- Creating SQLite database on `/tmp/indexify-extractors.db`.
- Getting the extractor description and serializing it to JSON string for insertion.
- Insert the description of the extractor to the database.

This functionality is executed while downloading the extractor:

```bash
indexify-extractor download ...
```

### To do

- Handle insertion error when an extractor description is already added.