### PR TITLE
cd: add deploy all extractors workflow

### DIFF
--- a/.github/workflows/publish-all-extractors.yml
+++ b/.github/workflows/publish-all-extractors.yml
@@ -1,0 +1,75 @@
+name: Publish all extractors
+
+on:
+  workflow_dispatch:
+
+jobs:
+  set-extractors-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          include=`cat extractors.json`
+          include=`echo $include | tr -d '\r\n '`
+          include=`echo $include | sed 's/"/\"/g'`
+          echo "matrix={\"include\": $include}" >> $GITHUB_OUTPUT
+
+  publish-extractor:
+    runs-on: ubuntu-latest
+    needs: set-extractors-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-extractors-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up variables
+        run: |
+          module=`echo "${{ matrix.module_name }}" | sed 's/\./\//g'`
+          full_dir=$(echo "${{ matrix.type }}/$module")
+
+          dir=$(dirname $full_dir | cut -d':' -f1)
+          class=$(echo $full_dir | cut -d':' -f2)
+          file=$(echo $full_dir | awk -F'[:/]' '{print $(NF-1)}')
+
+          echo $dir
+          echo $class
+          echo $file
+
+          echo "DIRECTORY=$dir" >> $GITHUB_ENV
+          echo "CLASS=$class" >> $GITHUB_ENV
+          echo "FILE=$file" >> $GITHUB_ENV
+
+      - name: Install extractor SDK
+        run: pip install ./extractor-sdk
+
+      - name: Package extractor
+        run: |
+          cd $DIRECTORY
+          pip install -r requirements.txt
+          indexify-extractor package --to-file extractor.dockerfile $FILE:$CLASS
+
+      - name: Get extractor name
+        run: |
+          cd $DIRECTORY
+          output=$(python -c "from $FILE import $CLASS as extractorclass; print(extractorclass.name)")
+          echo "NAME=$output" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push to Docker Hub
+        run: |
+          cd $DIRECTORY
+          docker buildx build --platform=linux/amd64,linux/arm64/v8 --push . -t $NAME:latest -f extractor.dockerfile;

--- a/.github/workflows/publish-all-extractors.yml
+++ b/.github/workflows/publish-all-extractors.yml
@@ -21,14 +21,16 @@ jobs:
   publish-extractor:
     runs-on: ubuntu-latest
     needs: set-extractors-matrix
+    continue-on-error: true
     strategy:
-      fail-fast: false
       matrix: ${{ fromJSON(needs.set-extractors-matrix.outputs.matrix) }}
     steps:
       - name: Checkout code
+        if: ${{ matrix.skip_deploy != true }}
         uses: actions/checkout@v4
 
       - name: Set up variables
+        if: ${{ matrix.skip_deploy != true }}
         run: |
           module=`echo "${{ matrix.module_name }}" | sed 's/\./\//g'`
           full_dir=$(echo "${{ matrix.type }}/$module")
@@ -46,30 +48,36 @@ jobs:
           echo "FILE=$file" >> $GITHUB_ENV
 
       - name: Install extractor SDK
+        if: ${{ matrix.skip_deploy != true }}
         run: pip install ./extractor-sdk
 
       - name: Package extractor
+        if: ${{ matrix.skip_deploy != true }}
         run: |
           cd $DIRECTORY
           pip install -r requirements.txt
           indexify-extractor package --to-file extractor.dockerfile $FILE:$CLASS
 
       - name: Get extractor name
+        if: ${{ matrix.skip_deploy != true }}
         run: |
           cd $DIRECTORY
           output=$(python -c "from $FILE import $CLASS as extractorclass; print(extractorclass.name)")
           echo "NAME=$output" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
+        if: ${{ matrix.skip_deploy != true }}
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
+        if: ${{ matrix.skip_deploy != true }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push to Docker Hub
+        if: ${{ matrix.skip_deploy != true }}
         run: |
           cd $DIRECTORY
           docker buildx build --platform=linux/amd64,linux/arm64/v8 --push . -t $NAME:latest -f extractor.dockerfile;

--- a/extractors.json
+++ b/extractors.json
@@ -10,16 +10,16 @@
   {"type": "embedding", "module_name": "openai-embedding.openai_embedding:OpenAIEmbeddingExtractor"},
   {"type": "embedding", "module_name": "scibert.scibert_uncased:SciBERTExtractor"},
   {"type": "audio", "module_name": "whisper-asr.whisper_extractor:WhisperExtractor"},
-  {"type": "audio", "module_name": "whisper-mlx.whisper_extractor:WhisperExtractor"},
+  {"type": "audio", "module_name": "whisper-mlx.whisper_extractor:WhisperExtractor", "skip_deploy": true},
   {"type": "audio", "module_name": "whisper-diarization.whisper_diarization:WhisperDiarizationExtractor"},
   {"type": "video", "module_name": "audio-extractor.audio_extractor:AudioExtractor"},
-  {"type": "video", "module_name": "face-extractor.face_extractor:FaceExtractor"},
+  {"type": "video", "module_name": "face-extractor.face_extractor:FaceExtractor", "skip_deploy": true},
   {"type": "video", "module_name": "keyframes.key_frame_extractor:KeyFrameExtractor"},
   {"type": "html", "module_name": "wikipedia.wikipedia:WikipediaExtractor"},
   {"type": "image", "module_name": "yolo.yolo_extractor:YoloExtractor"},
   {"type": "image", "module_name": "groundingdino.grounding_dino:GroundingDinoExtractor"},
   {"type": "image", "module_name": "moondream.moondream_extractor:MoondreamExtractor"},
-  {"type": "invoices", "module_name": "donut_cord.base_cord_v2:DonutBaseV2"},
+  {"type": "invoices", "module_name": "donut_cord.base_cord_v2:DonutBaseV2", "skip_deploy": true},
   {"type": "invoices", "module_name": "donut_invoice.donut_base_invoice:SimpleInvoiceParserExtractor"},
   {"type": "pdf", "module_name": "pdf-extractor.pdf_extractor:PDFExtractor"},
   {"type": "pdf", "module_name": "layoutlm_document_qa.layoutlm_document_qa:LayoutLMDocumentQA"},
@@ -27,5 +27,5 @@
   {"type": "pdf", "module_name": "unstructuredio.unstructured_pdf:UnstructuredIOExtractor"},
   {"type": "text", "module_name": "chunking.chunk_extractor:ChunkExtractor"},
   {"type": "text", "module_name": "summarization.summary_extractor:SummaryExtractor"},
-  {"type": "text", "module_name": "text-lid.language_extractor:LanguageExtractor"}
+  {"type": "text", "module_name": "text-lid.language_extractor:LanguageExtractor", "skip_deploy": true}
 ]


### PR DESCRIPTION
This PR adds a new workflow where on workflow dispatch trigger, it will attempt to publish all of the extractors available in the `extractors.json` file to Docker.

This is an example of the workflow run without the publish to docker steps:
https://github.com/edwinkys/indexify-extractors/actions/runs/8824954860

Most build succeeds and some fails due to various reason such as:

- `mlx` package not found in whisper-mlx extractor.
- `requirements.txt` file not found in donut-cord extractor
- Etc.

### There are 2 jobs

1. Setting up matrix to deploy the extractors
2. Deploying the extractor (using the matrix)

### Behaviour

The workflow disables fail-fast mechanism which ignores error deployment and keep running the deployment that can be run.

Note: the **Set up Docker Buildx** to **Push to Docker Hub** steps are taken from `publish-extractor.yml` created by @lucasjacks0n.