### PR TITLE
build: add pyyaml to dependencies

### DIFF
--- a/extractor-sdk/pyproject.toml
+++ b/extractor-sdk/pyproject.toml
@@ -30,6 +30,7 @@ genson = "^1.2.2"
 rich = "^13.7.1"
 fsspec = "^2024.2.0"
 indexify_text_splitter = "^0.1.1"
+pyyaml = "^6.0.1"
 
 [tool.poetry.dev-dependencies]
 syrupy = "^4.0.0"


### PR DESCRIPTION
Adds PyYAML dependencies to `extractor-sdk/pyproject.toml`.