### PR TITLE
remove duplicated task fields

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/agent.py
+++ b/extractor-sdk/indexify_extractor_sdk/agent.py
@@ -33,19 +33,12 @@ from .task_store import TaskStore, CompletedTask
 
 CONTENT_FRAME_SIZE = 1024 * 1024
 
-
 def begin_message(task_outcome, task: coordinator_service_pb2.Task, _executor_id):
     return ApiBeginExtractedContentIngest(
         BeginExtractedContentIngest=BeginExtractedContentIngest(
             task_id=task_outcome.task_id,
-            namespace=task.namespace,
-            output_to_index_table_mapping=task.output_index_mapping,
-            parent_content_id=task.content_metadata.id,
             executor_id=_executor_id,
             task_outcome=task_outcome.task_outcome,
-            extraction_policy=task.extraction_policy_id,
-            extractor=task.extractor,
-            index_tables=task.index_tables,
         )
     )
 

--- a/extractor-sdk/indexify_extractor_sdk/ingestion_api_models.py
+++ b/extractor-sdk/indexify_extractor_sdk/ingestion_api_models.py
@@ -39,15 +39,8 @@ class ApiContent(BaseModel):
 
 class BeginExtractedContentIngest(BaseModel):
     task_id: str
-    namespace: str
-    output_to_index_table_mapping: Dict[str, str]
-    parent_content_id: str
     executor_id: str
     task_outcome: str
-    extraction_policy: str
-    extractor: str
-    index_tables: List[str]
-    
 
 class ExtractedFeatures(BaseModel):
     content_id: str


### PR DESCRIPTION
Remove fields from BeginIngestExtractedContent that were duplicated in the Task.