### PR TITLE
fix: fix load module with specifying the module source

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/__init__.py
+++ b/extractor-sdk/indexify_extractor_sdk/__init__.py
@@ -1,18 +1,11 @@
-from .base_extractor import Content, Extractor, Feature, EmbeddingSchema, load_extractor
+from .base_extractor import Content, Extractor, Feature, EmbeddingSchema, load_extractor, EXTRACTORS_PATH
 import os
 import sys
 
 sys.path.append(".")
 
-extractors_path = os.path.join(os.path.expanduser("~"), ".indexify-extractors")
-if not os.path.exists(extractors_path):
-    os.mkdir(extractors_path)
-sys.path.append(extractors_path)
-all_subdirs = [d for d in os.listdir(extractors_path) ]
-for dir in all_subdirs:
-    print(f"Adding extractor dir: {dir} to PYTHONPATH")
-    sys.path.append(os.path.join(extractors_path, dir))
-
+if not os.path.exists(EXTRACTORS_PATH):
+    os.mkdir(EXTRACTORS_PATH)
 
 
 __all__ = [

--- a/extractor-sdk/indexify_extractor_sdk/extractor_worker.py
+++ b/extractor-sdk/indexify_extractor_sdk/extractor_worker.py
@@ -1,5 +1,5 @@
 from typing import List, Union, Dict, Optional
-from .base_extractor import Content, ExtractorWrapper, Feature, ExtractorDescription, EmbeddingSchema
+from .base_extractor import Content, ExtractorWrapper, Feature, ExtractorDescription, EmbeddingSchema, EXTRACTORS_PATH
 from pydantic import Json, BaseModel
 import concurrent
 from .downloader import get_db_path
@@ -64,15 +64,6 @@ def create_extractor_wrapper_map(id: Optional[str] = None):
     elif os.environ.get("EXTRACTOR_PATH"):
         print("adding extractor from environment")
         extractor = os.environ.get("EXTRACTOR_PATH")
-
-        extractor_directory = os.path.join(
-            os.path.expanduser("~"),
-            ".indexify-extractors",
-            os.path.basename(extractor.split(".")[0])
-        )
-
-        # This has to be done first to import the extractor module correctly
-        sys.path.append(extractor_directory)
 
         # TODO: Optimize this to load description from the database.
         extractor_wrapper = create_extractor_wrapper(extractor)

--- a/extractor-sdk/indexify_extractor_sdk/main.py
+++ b/extractor-sdk/indexify_extractor_sdk/main.py
@@ -7,6 +7,7 @@ import os
 from .list_extractors import list_extractors
 import sys
 from .downloader import get_db_path
+from .base_extractor import EXTRACTORS_PATH
 
 import multiprocessing
 from typing_extensions import Annotated
@@ -85,11 +86,9 @@ def join_server(
     print_version()
 
     # Check if any extractors are downloaded.
-    path = os.path.join(os.path.expanduser("~"), ".indexify-extractors")
-    if not os.path.isdir(path):
-        print(path)
+    if not os.path.isdir(EXTRACTORS_PATH):
         raise Exception("No extractors found. Download extractors using the downloader.")
-    
+
     print("workers ", workers)
     print("config path provided ", config_path)
 


### PR DESCRIPTION
- Fix extractor module import error due to name collision between Python package name and extractor module name.
- Consolidate extractor module import functionality using sys.path only from base_extractors.py.