### PR TITLE
retry operations failed in extractor

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/indexify_extractor.py
+++ b/extractor-sdk/indexify_extractor_sdk/indexify_extractor.py
@@ -80,6 +80,8 @@ def join(
         extractors=extractors,
         executor=executor,
         coordinator_addr=coordinator_addr,
+        num_workers=workers,
+        extractor_arg=extractor,
         listen_port=listen_port,
         ingestion_addr=ingestion_addr,
         advertise_addr=advertise_addr,


### PR DESCRIPTION
If an executor running extractor fails, recreate it and retry the tasks, up to certain limit.