### PR TITLE
fix: download extractors in docker in same dir as local

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/__init__.py
+++ b/extractor-sdk/indexify_extractor_sdk/__init__.py
@@ -1,4 +1,5 @@
 from .base_extractor import Content, Extractor, Feature, EmbeddingSchema, load_extractor, EXTRACTORS_PATH, EXTRACTOR_MODULE_PATH
+from .module_loader import load_indexify_extractors
 import os
 import sys
 
@@ -9,6 +10,8 @@ if not os.path.exists(EXTRACTORS_PATH):
 
 if not os.path.exists(EXTRACTOR_MODULE_PATH):
     os.mkdir(EXTRACTOR_MODULE_PATH)
+
+load_indexify_extractors(EXTRACTOR_MODULE_PATH)
 
 
 __all__ = [

--- a/extractor-sdk/indexify_extractor_sdk/__init__.py
+++ b/extractor-sdk/indexify_extractor_sdk/__init__.py
@@ -1,4 +1,4 @@
-from .base_extractor import Content, Extractor, Feature, EmbeddingSchema, load_extractor, EXTRACTORS_PATH
+from .base_extractor import Content, Extractor, Feature, EmbeddingSchema, load_extractor, EXTRACTORS_PATH, EXTRACTOR_MODULE_PATH
 import os
 import sys
 
@@ -6,6 +6,9 @@ sys.path.append(".")
 
 if not os.path.exists(EXTRACTORS_PATH):
     os.mkdir(EXTRACTORS_PATH)
+
+if not os.path.exists(EXTRACTOR_MODULE_PATH):
+    os.mkdir(EXTRACTOR_MODULE_PATH)
 
 
 __all__ = [

--- a/extractor-sdk/indexify_extractor_sdk/dockerfiles/Dockerfile.extractor
+++ b/extractor-sdk/indexify_extractor_sdk/dockerfiles/Dockerfile.extractor
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-WORKDIR /indexify
+WORKDIR /.indexify-extractors
 
 RUN apt-get update -y && \
     apt-get -y install git lsb-release ca-certificates apt-transport-https
@@ -9,8 +9,8 @@ RUN update-ca-certificates
 
 # Add Tini
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /indexify/tini
-RUN chmod +x /indexify/tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini tini
+RUN chmod +x tini
 
 RUN apt-get install -y python3.11 python3.11-dev python3-pip python3.11-venv && \
     apt-get install -y  {{ system_dependencies }} && \
@@ -22,25 +22,25 @@ ENV EXTRACTOR_PATH {{ extractor_path }}
 
 RUN python3.11 -m venv ve
 # Use the virtualenv, to make sure we're using the right Python version
-ENV PATH="/indexify/ve/bin:$PATH"
+ENV PATH="/.indexify-extractors/ve/bin:$PATH"
 
 RUN pip3 install --no-input --upgrade pip && \
     pip3 install --no-input wheel && \
     pip3 install --no-input {{ additional_pip_flags }} {{ python_dependencies }}
 
 {% if dev %}
-COPY indexify_extractor_sdk /indexify/indexify_extractor_sdk/indexify_extractor_sdk
+COPY indexify_extractor_sdk indexify_extractor_sdk/indexify_extractor_sdk
 
-COPY README.md /indexify/indexify_extractor_sdk/README.md
-COPY pyproject.toml /indexify/indexify_extractor_sdk/pyproject.toml
+COPY README.md indexify_extractor_sdk/README.md
+COPY pyproject.toml indexify_extractor_sdk/pyproject.toml
 
-RUN cd /indexify/indexify_extractor_sdk && pip3 install .
+RUN cd indexify_extractor_sdk && pip3 install .
 {% else %}
 RUN pip3 install --no-input indexify_extractor_sdk {{ additional_pip_flags }}
 {% endif %}
 
-# Copy over the extractor as {{module_name}}.py into /indexify/{{module_name}}.py
-COPY . /indexify/
+# Copy over the extractor as {{module_name}}.py into /indexify-extractors/{{module_name}}.py
+COPY . indexify-extractors/
 
 ENV TOKENIZERS_PARALLELISM=true
 

--- a/extractor-sdk/indexify_extractor_sdk/dockerfiles/Dockerfile.extractor
+++ b/extractor-sdk/indexify_extractor_sdk/dockerfiles/Dockerfile.extractor
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-WORKDIR /.indexify-extractors
+WORKDIR {{ workdir }}
 
 RUN apt-get update -y && \
     apt-get -y install git lsb-release ca-certificates apt-transport-https

--- a/extractor-sdk/indexify_extractor_sdk/downloader.py
+++ b/extractor-sdk/indexify_extractor_sdk/downloader.py
@@ -8,7 +8,7 @@ import subprocess
 from rich.console import Console
 from rich.panel import Panel
 from .extractor_worker import ExtractorWrapper
-from .base_extractor import ExtractorDescription, EXTRACTORS_PATH
+from .base_extractor import ExtractorDescription, EXTRACTORS_PATH, EXTRACTOR_MODULE_PATH
 
 console = Console()
 
@@ -133,7 +133,7 @@ def get_extractor_description(name: str) -> ExtractorDescription:
     return wrapper.describe()
 
 def get_extractor_full_name(directory: str):
-    path = os.path.join(EXTRACTORS_PATH, directory)
+    path = os.path.join(EXTRACTOR_MODULE_PATH, directory)
     name = find_extractor_subclasses(path)
     return f"{directory}.{name}"
 
@@ -194,9 +194,9 @@ def download_extractor(extractor_path):
     extractor_path = extractor_path.removeprefix("hub://")
     fs = fsspec.filesystem("github", org="tensorlakeai", repo="indexify-extractors")
 
-    fs.get(extractor_path, EXTRACTORS_PATH, recursive=True)
+    fs.get(extractor_path, EXTRACTOR_MODULE_PATH, recursive=True)
     base_extractor_path = os.path.basename(extractor_path)
-    install_dependencies(os.path.join(EXTRACTORS_PATH, base_extractor_path))
+    install_dependencies(os.path.join(EXTRACTOR_MODULE_PATH, base_extractor_path))
 
     # Store the extractor info in the database
 

--- a/extractor-sdk/indexify_extractor_sdk/module_loader.py
+++ b/extractor-sdk/indexify_extractor_sdk/module_loader.py
@@ -26,6 +26,3 @@ def load_indexify_extractors(base_path):
                 print(f"Successfully loaded: {module_name}")
             except Exception as e:
                 print(f"Failed to load: {module_name}, due to {e}")
-
-# Example usage
-load_indexify_extractors()

--- a/extractor-sdk/indexify_extractor_sdk/module_loader.py
+++ b/extractor-sdk/indexify_extractor_sdk/module_loader.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+def load_indexify_extractors(base_path):
+    # Resolve and expand the base path
+    base_path = os.path.expanduser(base_path)
+    base_dir = Path(base_path).resolve()
+
+    if not base_dir.is_dir():
+        raise ValueError(f"Invalid directory: {base_dir}")
+
+    # Add the base path's parent to sys.path for dynamic imports
+    sys.path.insert(0, str(base_dir.parent))
+
+    # Traverse the base directory and register submodules
+    for root, dirs, files in os.walk(base_dir):
+        if "__init__.py" in files:
+            rel_path = Path(root).relative_to(base_dir.parent)
+            module_name = ".".join(rel_path.parts)
+
+            # Import the submodule dynamically
+            try:
+                importlib.import_module(module_name)
+                print(f"Successfully loaded: {module_name}")
+            except Exception as e:
+                print(f"Failed to load: {module_name}, due to {e}")
+
+# Example usage
+load_indexify_extractors()

--- a/extractor-sdk/indexify_extractor_sdk/packager.py
+++ b/extractor-sdk/indexify_extractor_sdk/packager.py
@@ -14,6 +14,7 @@ import docker
 import logging
 import importlib.resources as pkg_resources
 import pathlib
+from .base_extractor import EXTRACTORS_PATH
 
 
 class ExtractorPackager:
@@ -221,9 +222,11 @@ class ExtractorPackager:
             raise
 
     def _generate_dockerfile(self) -> str:
+        workdir = EXTRACTORS_PATH.split("/")[-1]
         return (
             DockerfileTemplate()
             .configure(
+                workdir=workdir,
                 extractor_path=self.extractor_path,
                 system_dependencies=" ".join(
                     self.extractor_description["system_dependencies"]

--- a/extractor-sdk/indexify_extractor_sdk/packager_utils.py
+++ b/extractor-sdk/indexify_extractor_sdk/packager_utils.py
@@ -26,6 +26,7 @@ class DockerfileTemplate:
 
     def configure(
         self,
+        workdir: str,
         extractor_path: "ExtractorPathWrapper",
         system_dependencies: List[str],
         python_dependencies: List[str],
@@ -33,6 +34,7 @@ class DockerfileTemplate:
         dev: bool = False,
     ) -> "DockerfileTemplate":
         self.configuration_params = {
+            "workdir": workdir,
             "extractor_path": extractor_path.format(),
             "module_name": extractor_path.module_name,
             "module_file_name": extractor_path.file_name(),

--- a/extractor-sdk/pyproject.toml
+++ b/extractor-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexify-extractor-sdk"
-version = "0.0.58"
+version = "0.0.59"
 description = "Indexify Extractor SDK to build new extractors for extraction from unstructured data"
 authors = ["Diptanu Gon Choudhury <diptanu@tensorlake.ai>"]
 readme = "README.md"


### PR DESCRIPTION
- [x] Download extractors to .indexify-extractors/indexify_extractors
- [x] Do the same while installing the extractor in docker
- [x] When starting up locally and in Docker call module loader on the path indexify-extractors/indexify_extractors