### PR TITLE
ci: run text splitter workflow only when it changes

### DIFF
--- a/.github/workflows/publish-text-splitter.yml
+++ b/.github/workflows/publish-text-splitter.yml
@@ -12,7 +12,11 @@ on:
       - master
     tags:
       - "*"
+    paths:
+      - text_splitters/**
   pull_request:
+    paths:
+      - text_splitters/**
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR modifies the workflow to publish the text splitters to only run when something in the `text_splitters` directory changes.