### PR TITLE
fix: input param error due to nonetype

### DIFF
--- a/extractor-sdk/indexify_extractor_sdk/base_extractor.py
+++ b/extractor-sdk/indexify_extractor_sdk/base_extractor.py
@@ -243,8 +243,19 @@ class ExtractorWrapper:
         self._has_batch_extract = True if callable(extract_batch) else False
 
     def _param_from_json(self, param: Json) -> BaseModel:
-        param_dict = json.loads(param) if param is not None else {}
-        return self._param_cls.model_validate(param_dict) if self._param_cls is not None else None
+        if self._param_cls is None:
+            return {}
+
+        param_dict = {}
+        if param is not None and param != "null":
+            param_dict = json.loads(param)
+
+        try:
+            return self._param_cls.model_validate(param_dict)
+        except Exception as e:
+            print(f"Error validating input params: {e}")
+
+        return {}
 
     def extract_batch(
         self, content_list: Dict[str, Content], input_params: Dict[str, Json]


### PR DESCRIPTION
This PR fix an issue related to the input parameters:

```
failed to execute tasks e81469945036ded0 1 validation error for MoondreamConfig
Input should be a valid dictionary or instance of MoondreamConfig [type=model_type, input_value=None, input_type=NoneType]
```

This is caused when the task has no input parameters, given `null`. When attempting to get the input parameter, JSON converts `"null"` to `None`. This causes an uncaught error when running `model_validate(param_dict)` since it expects a dictionary.

This PR is tested well on `tensorlake/audio-extractor` and `
tensorlake/whisper-asr`.