### PR TITLE
fix: minor fix for schema alias

### DIFF
--- a/text/schema/schema_extractor.py
+++ b/text/schema/schema_extractor.py
@@ -3,6 +3,7 @@ from indexify_extractor_sdk import Content, Extractor, Feature
 from pydantic import BaseModel, Field
 from transformers import pipeline
 import os
+from typing import Dict, Optional
 from openai import OpenAI
 import google.generativeai as genai
 from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
@@ -11,9 +12,17 @@ class SchemaExtractorConfig(BaseModel):
     service: str = Field(default='openai')
     model_name: Optional[str] = Field(default='gpt-3.5-turbo')
     key: Optional[str] = Field(default=None)
-    schema: dict = Field(default={'properties': {'name': {'title': 'Name', 'type': 'string'}}, 'required': ['name'], 'title': 'User', 'type': 'object'})
+    schema_config: Dict = Field(default={
+        'properties': {'name': {'title': 'Name', 'type': 'string'}},
+        'required': ['name'],
+        'title': 'User',
+        'type': 'object'
+    }, alias='schema')
     data: Optional[str] = Field(default=None)
-    additional_messages: str = Field(default='Extract information in JSON according to this schema and return only the output. ')
+    additional_messages: str = Field(default='Extract information in JSON according to this schema and return only the output.')
+
+    class Config:
+        allow_population_by_field_name = True
 
 class SchemaExtractor(Extractor):
     name = "tensorlake/schema"
@@ -93,7 +102,7 @@ class SchemaExtractor(Extractor):
 if __name__ == "__main__":
     schema = {'properties': {'invoice_number': {'title': 'Invoice Number', 'type': 'string'}, 'date': {'title': 'Date', 'type': 'string'}, 'account_number': {'title': 'Account Number', 'type': 'string'}, 'owner': {'title': 'Owner', 'type': 'string'}, 'address': {'title': 'Address', 'type': 'string'}, 'last_month_balance': {'title': 'Last Month Balance', 'type': 'string'}, 'current_amount_due': {'title': 'Current Amount Due', 'type': 'string'}, 'registration_key': {'title': 'Registration Key', 'type': 'string'}, 'due_date': {'title': 'Due Date', 'type': 'string'}}, 'required': ['invoice_number', 'date', 'account_number', 'owner', 'address', 'last_month_balance', 'current_amount_due', 'registration_key', 'due_date'], 'title': 'User', 'type': 'object'}
     data = Content.from_text('Axis\nSTATEMENTInvoice No. 20240501-336593\nDate: 4/19/2024\nAccount Number:\nOwner:\nProperty:922000203826\nJohn Doe\n200 Park Avenue, Manhattan\nJohn Doe\n200 Park Avenue Manhattan\nNew York 10166SUMMARY OF ACCOUNT\nLast Month Balance:\nCurrent Amount Due:$653.03\n$653.03\nAccount details on back.\nProfessionally\nprepared by:\nSTATEMENT MESSAGE\nWelcome to Action Property Management! We are excited to be\nserving your community. Our Community Care team is more than\nhappy to assist you with any billing questions you may have. For\ncontact options, please visit www.actionlife.com/contact. Visit the\nAction Property Management web page at: www.actionlife.com.BILLING QUESTIONS\nScan the QR code to\ncontact our\nCommunity Care\nteam.\nactionlife.com/contact\nCommunityCare@actionlife.com\nRegister your Resident\nPortal account now!\nRegistration Key/ID:\nFLOWR2U\nresident.actionlife.com\nTo learn more about issues facing HOAs, say "Hey Siri, search the web for The Uncommon Area by Action Property Management."\nMake checks payable to:\nAxisAccount Number: 922000203826\nOwner: John Doe\nPLEASE REMIT PAYMENT TO:\n** AUTOPAY SCHEDULED **\n** NO REMITTANCE NECESSARY **CURRENT AMOUNT DUE\n$653.03\nDUE DATE\n5/1/2024\n0049 00008330 0000922000203826 7 00065303 00000000 9')
-    input_params = SchemaExtractorConfig(service="openai", schema=schema)
+    input_params = SchemaExtractorConfig(service="openai", schema=schema, key="")
     extractor = SchemaExtractor()
     results = extractor.extract(data, params=input_params)
     print(results)


### PR DESCRIPTION
Fixes the following issue: https://github.com/tensorlakeai/indexify-extractors/issues/199

- `schema` alias reserved by `pydantic`
- changes the name of the `schema` field 
- creates a `config` subclass for:
    - allowing one to use either the field name or the alias when creating instances of the model.