### PR TITLE
modify: schema extractor to infer schemas from examples

### DIFF
--- a/text/schema/schema_extractor.py
+++ b/text/schema/schema_extractor.py
@@ -41,6 +41,7 @@ class SchemaExtractor(Extractor):
         model_name = params.model_name
         key = params.key
         schema = params.schema
+        example_text = params.example_text
         data = params.data
         additional_messages = params.additional_messages
         if data is None:
@@ -55,6 +56,14 @@ class SchemaExtractor(Extractor):
                     client = OpenAI()
                 else:
                     client = OpenAI(api_key=key)
+                if schema is None and example_text:
+                    schema = client.chat.completions.create(
+                        model=model_name,
+                        messages=[
+                            {"role": "system", "content": "Extract a JSON schema based on the examples" + str(example_text)},
+                            {"role": "user", "content": data}
+                        ]
+                    )
                 response = client.chat.completions.create(
                     model=model_name,
                     messages=[
@@ -78,6 +87,8 @@ class SchemaExtractor(Extractor):
                 safety_settings = [ { "category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE", }, { "category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE", }, { "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_NONE", }, { "category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_NONE", }, ]
                 model = genai.GenerativeModel( model_name="gemini-1.5-flash-latest", safety_settings=safety_settings, generation_config=generation_config, )
                 chat_session = model.start_chat( history=[ ] )
+                if schema is None and example_text:
+                    schema = chat_session.send_message("Extract a JSON schema based on the examples" + str(example_text))
                 response = chat_session.send_message(additional_messages + str(schema) + " " + data)
                 response_content = response.text
                 feature = Feature.metadata(value={"model": model_name}, name="text")
@@ -85,9 +96,13 @@ class SchemaExtractor(Extractor):
         if '/' in service:
             model = AutoModelForCausalLM.from_pretrained(service, device_map="cuda", torch_dtype="auto", trust_remote_code=True)
             tokenizer = AutoTokenizer.from_pretrained(service)
-            messages = [{"role": "system", "content": additional_messages + str(schema)}, {"role": "user", "content": data}]
             pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
             generation_args = {"max_new_tokens": 500, "return_full_text": False, "temperature": 0.0, "do_sample": False}
+            if schema is None and example_text:
+                schema_messages = [{"role": "system", "content": "Extract a JSON schema based on the examples" + str(example_text)}, {"role": "user", "content": data}]
+                schema = pipe(schema_messages, **generation_args)
+                schema = schema[0]['generated_text']
+            messages = [{"role": "system", "content": additional_messages + str(schema)}, {"role": "user", "content": data}]
             output = pipe(messages, **generation_args)
             response_content = output[0]['generated_text']
             feature = Feature.metadata(value={"model": service}, name="text")
@@ -101,8 +116,36 @@ class SchemaExtractor(Extractor):
 
 if __name__ == "__main__":
     schema = {'properties': {'invoice_number': {'title': 'Invoice Number', 'type': 'string'}, 'date': {'title': 'Date', 'type': 'string'}, 'account_number': {'title': 'Account Number', 'type': 'string'}, 'owner': {'title': 'Owner', 'type': 'string'}, 'address': {'title': 'Address', 'type': 'string'}, 'last_month_balance': {'title': 'Last Month Balance', 'type': 'string'}, 'current_amount_due': {'title': 'Current Amount Due', 'type': 'string'}, 'registration_key': {'title': 'Registration Key', 'type': 'string'}, 'due_date': {'title': 'Due Date', 'type': 'string'}}, 'required': ['invoice_number', 'date', 'account_number', 'owner', 'address', 'last_month_balance', 'current_amount_due', 'registration_key', 'due_date'], 'title': 'User', 'type': 'object'}
-    data = Content.from_text('Axis\nSTATEMENTInvoice No. 20240501-336593\nDate: 4/19/2024\nAccount Number:\nOwner:\nProperty:922000203826\nJohn Doe\n200 Park Avenue, Manhattan\nJohn Doe\n200 Park Avenue Manhattan\nNew York 10166SUMMARY OF ACCOUNT\nLast Month Balance:\nCurrent Amount Due:$653.03\n$653.03\nAccount details on back.\nProfessionally\nprepared by:\nSTATEMENT MESSAGE\nWelcome to Action Property Management! We are excited to be\nserving your community. Our Community Care team is more than\nhappy to assist you with any billing questions you may have. For\ncontact options, please visit www.actionlife.com/contact. Visit the\nAction Property Management web page at: www.actionlife.com.BILLING QUESTIONS\nScan the QR code to\ncontact our\nCommunity Care\nteam.\nactionlife.com/contact\nCommunityCare@actionlife.com\nRegister your Resident\nPortal account now!\nRegistration Key/ID:\nFLOWR2U\nresident.actionlife.com\nTo learn more about issues facing HOAs, say "Hey Siri, search the web for The Uncommon Area by Action Property Management."\nMake checks payable to:\nAxisAccount Number: 922000203826\nOwner: John Doe\nPLEASE REMIT PAYMENT TO:\n** AUTOPAY SCHEDULED **\n** NO REMITTANCE NECESSARY **CURRENT AMOUNT DUE\n$653.03\nDUE DATE\n5/1/2024\n0049 00008330 0000922000203826 7 00065303 00000000 9')
-    input_params = SchemaExtractorConfig(service="openai", schema=schema, key="")
+    examples = [
+    {
+        "type": "object",
+        "properties": {
+            "employer_name": {"type": "string", "title": "Employer Name"},
+            "employee_name": {"type": "string", "title": "Employee Name"},
+            "wages": {"type": "number", "title": "Wages"},
+            "federal_tax_withheld": {"type": "number", "title": "Federal Tax Withheld"},
+            "state_wages": {"type": "number", "title": "State Wages"},
+            "state_tax": {"type": "number", "title": "State Tax"}
+        },
+        "required": ["employer_name", "employee_name", "wages", "federal_tax_withheld", "state_wages", "state_tax"]
+    },
+    {
+        "type": "object",
+        "properties": {
+            "booking_reference": {"type": "string", "title": "Booking Reference"},
+            "passenger_name": {"type": "string", "title": "Passenger Name"},
+            "flight_number": {"type": "string", "title": "Flight Number"},
+            "departure_airport": {"type": "string", "title": "Departure Airport"},
+            "arrival_airport": {"type": "string", "title": "Arrival Airport"},
+            "departure_time": {"type": "string", "title": "Departure Time"},
+            "arrival_time": {"type": "string", "title": "Arrival Time"}
+        },
+        "required": ["booking_reference", "passenger_name", "flight_number", "departure_airport", "arrival_airport", "departure_time", "arrival_time"]
+    }]
+
+
+    data = Content.from_text("Form 1040\nForms W-2 & W-2G Summary\n2023\nKeep for your records\n Name(s) Shown on Return\nSocial Security Number\nJohn H & Jane K Doe\n321-12-3456\nEmployer\nSP\nFederal Tax\nState Wages\nState Tax\nForm W-2\nWages\nAcmeware Employer\n143,433.\n143,433.\n1,000.\nTotals.\n143,433.\n143,433.\n1,000.\nForm W-2 Summary\nBox No.\nDescription\nTaxpayer\nSpouse\nTotal\nTotal wages, tips and compensation:\n1\na\nW2 box 1 statutory wages reported on Sch C\nW2 box 1 inmate or halfway house wages .\n6\nc\nAll other W2 box 1 wages\n143,433.\n143,433.\nd\nForeign wages included in total wages\ne\n0.\n0.\n2\nTotal federal tax withheld\n 3 & 7 Total social security wages/tips .\n143,566.\n143,566.\n4\nTotal social security tax withheld\n8,901.\n8,901.\n5\nTotal Medicare wages and tips\n143,566.\n143,566.\n6\nTotal Medicare tax withheld . :\n2,082.\n2,082.\n8\nTotal allocated tips .\n9\nNot used\n10 a\nTotal dependent care benefits\nb\nOffsite dependent care benefits\nc\nOnsite dependent care benefits\n11\n Total distributions from nonqualified plans\n12 a\nTotal from Box 12\n3,732.\n3,732.\nElective deferrals to qualified plans\n133.\n133.\nc\nRoth contrib. to 401(k), 403(b), 457(b) plans .\n.\n1 Elective deferrals to government 457 plans\n2 Non-elective deferrals to gov't 457 plans .\ne\nDeferrals to non-government 457 plans\nf\nDeferrals 409A nonqual deferred comp plan .\n6\nIncome 409A nonqual deferred comp plan .\nh\nUncollected Medicare tax :\nUncollected social security and RRTA tier 1\nj\nUncollected RRTA tier 2 . . .\nk\nIncome from nonstatutory stock options\nNon-taxable combat pay\nm\nQSEHRA benefits\nTotal other items from box 12 .\nn\n3,599.\n3,599.\n14 a\n Total deductible mandatory state tax .\nb\nTotal deductible charitable contributions\nc\nTotal state deductible employee expenses .\nd\n Total RR Compensation .\ne\nTotal RR Tier 1 tax .\nf\nTotal RR Tier 2 tax . -\nTotal RR Medicare tax .\ng\nh\nTotal RR Additional Medicare tax .\ni\nTotal RRTA tips. : :\nj\nTotal other items from box 14\nk\nTotal sick leave subject to $511 limit\nTotal sick leave subject to $200 limit\nm\nTotal emergency family leave wages\n16\nTotal state wages and tips .\n143,433.\n143,433.\n17\nTotal state tax withheld\n1,000.\n1,000.\n19\nTotal local tax withheld .")
+    input_params = SchemaExtractorConfig(service="openai", schema=schema, example_text=str(examples))
     extractor = SchemaExtractor()
     results = extractor.extract(data, params=input_params)
     print(results)

--- a/text/schema/schema_extractor.py
+++ b/text/schema/schema_extractor.py
@@ -18,6 +18,7 @@ class SchemaExtractorConfig(BaseModel):
         'title': 'User',
         'type': 'object'
     }, alias='schema')
+    example_text: Optional[str] = Field(default=None)
     data: Optional[str] = Field(default=None)
     additional_messages: str = Field(default='Extract information in JSON according to this schema and return only the output.')
 


### PR DESCRIPTION
## What?

This PR does the following:

- Modifies `schema_extractor.py` to have another optional field `example_text`
- This will allow the user to set the create the `schema` from the data using few shot examples
- The `examples` must be supplied by the user in a string format
- The user has the choice to supply the `schema` or `example_text` or both
     ° In case both are supplied `schema` will be considered

## Why?

JSON schemas are difficult to write and create for users who have a chunk of data with varied fields and subfields. This will allow the language model of choice to do the heavy-lifting for the user by interpreting the correct schema for the data based on a few related examples.

