### PR TITLE
Use s3 bucket to serve extractors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ indexify-extractor list
 #### Download an Extractor
 Find the name of the extractor you want.
 ```bash
-indexify-extractor download hub://embedding/minilm-l6
+indexify-extractor download tensorlake/minilm-l6
 ```
 
 #### Load and Run in Notebook or Python Applications 
@@ -49,7 +49,7 @@ config.schema()
 
 #### Extract Locally on shell -
 ```bash
-indexify-extractor run-local indexify_extractor.minilm_l6:MiniLML6Extractor --text "hello world" // or --file 
+indexify-extractor run-local indexify_extractors.minilm-l6.minilm_l6:MiniLML6Extractor --text "hello world" // or --file
 ```
 
 #### Run Extractors as a Service for Continous Extraction and Indexing with Indexify Server

--- a/extractor-sdk/indexify_extractor_sdk/downloader.py
+++ b/extractor-sdk/indexify_extractor_sdk/downloader.py
@@ -215,12 +215,15 @@ def download_extractor(extractor_name):
 
     console.print("[bold #4AA4F4]Downloading Extractor...[/]")
     extractors_index = extractors_by_name()
-    fs = fsspec.filesystem("github", org="tensorlakeai", repo="indexify-extractors")
+
+    fs = fsspec.filesystem('s3', anon=True)
+
     if extractor_name not in extractors_index:
         console.print(f"[bold #f04318]Extractor {extractor_name} not found[/]")
         console.print(f"[bold #f04318]Use command: [yellow]indexify-extractor list[/yellow] to see the list of available extractors[/]")
         return
-    extractor_path = extractors_index[extractor_name]["path"]
+
+    extractor_path = f's3://indexifyextractors/indexify-extractors/{extractors_index[extractor_name]["path"]}'
 
     fs.get(extractor_path, EXTRACTOR_MODULE_PATH, recursive=True)
     base_extractor_path = os.path.basename(extractor_path)

--- a/extractor-sdk/indexify_extractor_sdk/utils.py
+++ b/extractor-sdk/indexify_extractor_sdk/utils.py
@@ -29,8 +29,9 @@ def read_extractors_json_file(filename):
     #     json_content = json.load(file)
     # return json_content
 
-    fs = fsspec.filesystem("github", org="tensorlakeai", repo="indexify-extractors")
-    file_path = filename
+    file_path = f's3://indexifyextractors/indexify-extractors/{filename}'
+
+    fs = fsspec.filesystem('s3', anon=True)
 
     with fs.open(file_path, "r") as file:
         # Load the JSON content from the file


### PR DESCRIPTION
Use s3 bucket to serve extractors, instead of github.