### PR TITLE
fix: tensorlake/paddleocr_extractor not starting 

### DIFF
--- a/pdf/paddleocrextractor/requirements.txt
+++ b/pdf/paddleocrextractor/requirements.txt
@@ -1,7 +1,5 @@
-paddlepaddle==2.4.2
-paddleocr==2.6.1.3
+paddlepaddle==2.6.1
+paddleocr==2.8.1
 pdf2image==1.17.0
-pytesseract==0.3.9
+pytesseract==0.3.10
 fitz==0.0.1.dev2
-pydantic==1.10.7
-


### PR DESCRIPTION

Minor and easy fix for:
```
ERROR indexify::api: API Error: 500 Internal Server Error - status: Aborted, message: "unable to create extraction policies: Extractor with name tensorlake/paddleocr_extractor not found", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Fri, 26 Jul 2024 18:55:29 GMT", "content-length": "0"} }
```
Mostly because of the dependency of previous versions of paddlepaddle not being backward compatible.
Changed to latest versions 

Tested here: [Indexify-paddleocr-extractor-testing](https://colab.research.google.com/drive/18o-3p1G1gt4yfDTUjayORHf4-ddW5XkI?usp=sharing)