### PR TITLE
Update pdf_extractor.py to give proper aligned output

### DIFF
--- a/pdf/pdfextractor/pdf_extractor.py
+++ b/pdf/pdfextractor/pdf_extractor.py
@@ -33,8 +33,18 @@ class PDFExtractor(Extractor):
                     contents.append(Content.from_text(md_text))
                 else:
                     with pymupdf.open(inputtmpfile.name) as doc:
-                        for page_num, page in enumerate(doc):
-                            text = page.get_text()
+                        # Iterate over each page
+                        for page_num in range(len(doc)):
+                            page = doc[page_num]
+                            # Extract text by blocks, which are sorted top to bottom
+                            blocks = page.get_text("blocks")
+                            # Sort blocks by their top-left y-coordinate (blocks[1])
+                            blocks = sorted(blocks, key=lambda b: (b[1], b[0]))
+                    
+                            text = ""
+                            for block in blocks:
+                                # Each block has coordinates and text; print the text
+                                text += block[4]
                             contents.append(Content.from_text(text, features=[Feature.metadata({"page_num": page_num})]))
 
             if "image" in params.output_types:


### PR DESCRIPTION
get_text("blocks"): This method extracts text along with its position on the page. The text is divided into blocks, which are not necessarily in reading order.
Sorting Blocks: We sort these blocks by their top-left y-coordinate (block[1]) first, and then by x-coordinate (block[0]). This sorting helps maintain a top-to-bottom reading order.